### PR TITLE
fix field name and values; no action on merge

### DIFF
--- a/.github/workflows/update_contributions.yml
+++ b/.github/workflows/update_contributions.yml
@@ -1,8 +1,5 @@
 name: Update Contributions
 on:
-  push:
-    branches:
-      - main
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '45 4 * * *'

--- a/contributions.yaml
+++ b/contributions.yaml
@@ -1476,6 +1476,8 @@ contributions:
   minRevision: 0
   maxRevision: 0
   download: http://www.lagers.org.uk/processing/appletmaker/AppletMaker.zip
+  override:
+    maxRevision: 228
 - id: 97
   source: https://andrusiv.com/android-select-file/download/SelectFile.txt
   status: VALID
@@ -3412,7 +3414,7 @@ contributions:
   prettyVersion: v1.2
   minRevision: 0
   maxRevision: 0
-  compatibleModesList: ''
+  modes: ''
   download: http://mad4j.github.io/book-mdpc/book-mdpc.zip
   override:
     categories:
@@ -4158,7 +4160,7 @@ contributions:
   prettyVersion: 1.0.1
   minRevision: 0
   maxRevision: 0
-  compatibleModesList: jycessing.mode.PythonMode
+  modes: jycessing.mode.PythonMode
   download: https://coding-creative.dringtech.com/examples/coding-creative-examples.zip
 - id: 244
   source: http://giftedapprentice.com/ewbIK/ewbIK.txt

--- a/scripts/parse_and_validate_properties_txt.py
+++ b/scripts/parse_and_validate_properties_txt.py
@@ -27,6 +27,7 @@ class PropertiesBase(BaseModel):
     prettyVersion: str
     minRevision: int = Field(0)
     maxRevision: int = Field(0)
+    modes: Optional[str] = Field(None, alias='compatibleModesList')
 
     model_config = ConfigDict(
         extra='allow',


### PR DESCRIPTION
Needed changes to database, when compared to legacy data output:
1. id 96, needs `maxRevision` override of 228
2. ids 243, 205, two examples with modes need a database field remapping from `compatibleModesList` to `modes`

Also remove a trigger from the update contributions workflow - no longer run on changes to main. This way, can accumulate changes before running  manually, or just let the daily run pick up the changes.