### PR TITLE
do not export unset fields, and set min python version

### DIFF
--- a/.github/workflows/update_contributions.yml
+++ b/.github/workflows/update_contributions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '>=3.11'
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/scripts/parse_and_validate_properties_txt.py
+++ b/scripts/parse_and_validate_properties_txt.py
@@ -101,19 +101,19 @@ def validate_existing(properties_dict):
     # validation on existing contribution is weaker
     properties = PropertiesExisting.model_validate(properties_dict)
 
-    return properties.model_dump()
+    return properties.model_dump(exclude_unset=True)
 
 def validate_new(properties_dict):
     # new contribution has stronger validation
     properties = PropertiesBase.model_validate(properties_dict)
 
-    return properties.model_dump()
+    return properties.model_dump(exclude_unset=True)
 
 def validate_new_library(properties_dict):
     # new contribution has stronger validation
     properties = LibraryPropertiesNew.model_validate(properties_dict)
 
-    return properties.model_dump()
+    return properties.model_dump(exclude_unset=True)
 
 def set_output(output_object):
     with open(os.environ['GITHUB_OUTPUT'],'a') as f:


### PR DESCRIPTION
The exclude_unset=True means that optional fields that are not set in the input dict are not included when dumped. Without this, the optional 'modes' field, if not set, would be output with a null value.

The update script required a minimum version of 3.11, so set this in the workflow.