### PR TITLE
Fix new contribution worlfow to only trigger on relevant issues

### DIFF
--- a/.github/workflows/update_contributions.yml
+++ b/.github/workflows/update_contributions.yml
@@ -4,16 +4,11 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '45 4 * * *'
   workflow_dispatch:
-  issues:
-    types:
-      - opened
 permissions:
   contents: write
 
 jobs:
   update:
-    if: >
-      github.event.issue.labels.*.name contains 'new-contribution'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Trigger the workflow when an issue is opened and filter on the `new-contribution` label to only run for issues that contain a new contribution. 

closes #17 