### PR TITLE
Reorder issue template and add doc URL field

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_new-contribution.yaml
+++ b/.github/ISSUE_TEMPLATE/1_new-contribution.yaml
@@ -37,6 +37,18 @@ body:
   - type: markdown
     attributes:
       value: |
+        Please provide a link to your contribution's documentation page. 
+  - type: input
+    id: documentation_url
+    attributes:
+      label: documentation_url
+      description: URL of the documentation page for your contribution.
+      placeholder: https://
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
         Once you submit this form, the properties file found at the url will be parsed and validated. 
         
         The result of this validation will be added to this issue:


### PR DESCRIPTION
- Rename new-contribution.yaml to 1_new-contribution.yaml to have it show first in the list of issue templates
- Add an input field for documentation page URL