### PR TITLE
Update issue templates to use labels for contribution type

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -1,6 +1,6 @@
-name: 💙 New Library 
+name: 💙 New Library
 description: Submit a new Processing library
-labels: ["new-contribution"]
+labels: ["new-contribution", "library"]
 body:
   - type: markdown
     attributes:
@@ -48,7 +48,3 @@ body:
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your library to the repository.
         - If invalid, a comment will be added with details of the error. You will need to fix the file and resubmit.
-  - type: hidden
-    id: contribution_type
-    attributes:
-      value: library

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -1,6 +1,6 @@
 name: 🔨 New Tool
 description: Submit a new Processing tool
-labels: ["new-contribution"]
+labels: ["new-contribution", "tool"]
 body:
   - type: markdown
     attributes:
@@ -48,7 +48,3 @@ body:
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your tool to the repository.
         - If invalid, a comment will be added with details of the error. You will need to fix the file and resubmit.
-  - type: hidden
-    id: contribution_type
-    attributes:
-      value: tool

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -1,6 +1,6 @@
 name: 👗 New Mode
 description: Submit a new Processing mode
-labels: ["new-contribution"]
+labels: ["new-contribution", "mode"]
 body:
   - type: markdown
     attributes:
@@ -48,7 +48,3 @@ body:
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your mode to the repository.
         - If invalid, a comment will be added with details of the error. You will need to fix the file and resubmit.
-  - type: hidden
-    id: contribution_type
-    attributes:
-      value: mode

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -1,6 +1,6 @@
 name: 📦 New Example Pack
 description: Submit a new Processing example pack
-labels: ["new-contribution"]
+labels: ["new-contribution", "examples"]
 body:
   - type: markdown
     attributes:
@@ -48,7 +48,3 @@ body:
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your example pack to the repository.
         - If invalid, a comment will be added with details of the error. You will need to fix the file and resubmit.
-  - type: hidden
-    id: contribution_type
-    attributes:
-      value: examples

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -35,11 +35,19 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Determine category from labels
+        id: determineCategory
+        run: echo "::set-output name=category::${{
+          contains(github.event.issue.labels.*.name, 'examples') && 'examples'
+          || contains(github.event.issue.labels.*.name, 'mode') && 'mode'
+          || contains(github.event.issue.labels.*.name, 'tool') && 'tool'
+          || contains(github.event.issue.labels.*.name, 'library') && 'library'}}"
+
       - name: Read and validate properties txt file
         id: parseProps
         run: >
           python -u scripts/parse_and_validate_properties_txt.py \
-            ${{ fromJson(steps.parseIssue.outputs.payload).contribution_type }} \
+            ${{ steps.determineCategory.outputs.category }} \
             "${{ fromJson(steps.parseIssue.outputs.payload).properties_url }}"
 
       - name: add comment to issue
@@ -57,7 +65,7 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             There was an error in reading in your file and parsing it.
-            
+
             ${{ steps.parseProps.outputs.error }}
   create-pr:
     needs: validate


### PR DESCRIPTION
Did not seem possible to set the `contribution_type` in a hidden way so using labels instead. Needs testing.