### PR TITLE
Fix workflow for ingesting issues based on labels

### DIFF
--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -45,17 +45,17 @@ jobs:
           echo "labels=$labels" >> $GITHUB_ENV
 
       - name: Determine category from labels
-          id: determineCategory
-          run: |
-            labels_json='${{ env.labels }}'
-            echo "Labels: $labels_json"
-            category=$(python scripts/determine_category.py "$labels_json")
-            if [ -z "$category" ]; then
-              echo "Category is empty. Please ensure the issue has a valid label."
-              exit 1
-            fi
-            echo "category=$category" >> $GITHUB_OUTPUT
-            echo "Category found: $category"
+        id: determineCategory
+        run: |
+          labels_json='${{ env.labels }}'
+          echo "Labels: $labels_json"
+          category=$(python scripts/determine_category.py "$labels_json")
+          if [ -z "$category" ]; then
+            echo "Category is empty. Please ensure the issue has a valid label."
+            exit 1
+          fi
+          echo "category=$category" >> $GITHUB_OUTPUT
+          echo "Category found: $category"
 
       - name: Debug payload
         run: echo "${{ steps.parseIssue.outputs.payload }}"

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Get issue labels
         id: getLabels
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           labels=$(gh issue view "${{ github.event.issue.number }}" --json labels -q '.labels|map(.name)')
           echo "Labels: $labels"

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -37,16 +37,21 @@ jobs:
 
       - name: Get issue labels
         id: getLabels
-        uses: snnaplab/get-labels-action@v1
-        with:
-          number: ${{ github.event.issue.number }}
+        run: |
+          labels=$(gh issue view "${{ github.event.issue.number }}" --json labels -q '.labels|map(.name)')
+          echo "Labels: $labels"
+          echo "labels=$labels" >> $GITHUB_ENV
 
       - name: Determine category from labels
         id: determineCategory
         run: |
-          labels_json="${{ steps.getLabels.outputs.labels }}"
+          labels_json="${{ env.labels }}"
           echo "Labels: $labels_json"
           category=$(python scripts/determine_category.py "$labels_json")
+          if [ -z "$category" ]; then
+            echo "Category is empty. Please ensure the issue has a valid label."
+            exit 1
+          fi
           echo "category=$category" >> $GITHUB_OUTPUT
           echo "Category found: $category"
 

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -35,16 +35,18 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Get issue labels
+        id: getLabels
+        uses: snnaplab/get-labels-action@v1
+        with:
+          number: ${{ github.event.issue.number }}
+
       - name: Determine category from labels
         id: determineCategory
         run: |
-          labels_json="${{ toJson(github.event.issue.labels) }}"
+          labels_json="${{ steps.getLabels.outputs.labels }}"
           echo "Labels: $labels_json"
           category=$(python scripts/determine_category.py "$labels_json")
-          if [ -z "$category" ]; then
-            echo "Category is empty. Please ensure the issue has a valid label."
-            exit 1
-          fi
           echo "category=$category" >> $GITHUB_OUTPUT
           echo "Category found: $category"
 

--- a/.github/workflows/issue_to_pr.yml
+++ b/.github/workflows/issue_to_pr.yml
@@ -45,17 +45,17 @@ jobs:
           echo "labels=$labels" >> $GITHUB_ENV
 
       - name: Determine category from labels
-        id: determineCategory
-        run: |
-          labels_json="${{ env.labels }}"
-          echo "Labels: $labels_json"
-          category=$(python scripts/determine_category.py "$labels_json")
-          if [ -z "$category" ]; then
-            echo "Category is empty. Please ensure the issue has a valid label."
-            exit 1
-          fi
-          echo "category=$category" >> $GITHUB_OUTPUT
-          echo "Category found: $category"
+          id: determineCategory
+          run: |
+            labels_json='${{ env.labels }}'
+            echo "Labels: $labels_json"
+            category=$(python scripts/determine_category.py "$labels_json")
+            if [ -z "$category" ]; then
+              echo "Category is empty. Please ensure the issue has a valid label."
+              exit 1
+            fi
+            echo "category=$category" >> $GITHUB_OUTPUT
+            echo "Category found: $category"
 
       - name: Debug payload
         run: echo "${{ steps.parseIssue.outputs.payload }}"


### PR DESCRIPTION
The workflow should now correctly accept issues with the `library`, `mode`, `tool` and `examples` labels.