### PR TITLE
Clarified the instructions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -20,9 +20,9 @@ body:
         The `.txt` file (e.g., `myLibrary.txt`) is necessary for submitting your library. It should be a direct copy of your `library.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
-        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
-        - `.txt` file: `https://mywebsite.com/releases/latest/myLibrary.txt`
-        - `.zip` file: `https://mywebsite.com/releases/latest/myLibrary.zip`
+        If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myLibrary.txt`
+        - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myLibrary.zip`
 
         For more details, see the [Release Artifacts section of the Library Guidelines](https://github.com/processing/processing4/wiki/Library-Guidelines#release-artifacts).
   - type: input

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -15,7 +15,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the Properties File
+        #### About the Properties File
 
         A properties file (e.g., `myLibrary.txt`) is necessary for submitting your library. It should be a direct copy of your `library.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -11,13 +11,25 @@ body:
 
         If you need help creating a library, see the [Library Guidelines](https://github.com/processing/processing4/wiki/Library-Guidelines) or ask on the [Processing Forum](https://discourse.processing.org/).
 
-        Please provide the necessary information below.
+        Please complete the form below with the necessary information about your library.
+  - type: markdown
+    attributes:
+      value: |
+        ### About the `.txt` File
 
+        The `.txt` file (e.g., `myLibrary.txt`) is necessary for submitting your library. It should be a direct copy of your `library.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+
+        **Example:**
+        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://mywebsite.com/releases/latest/myLibrary.txt`
+        - `.zip` file: `https://mywebsite.com/releases/latest/myLibrary.zip`
+
+        For more details, see the [Release Artifacts section of the Library Guidelines](https://github.com/processing/processing4/wiki/Library-Guidelines#release-artifacts).
   - type: input
     id: properties_url
     attributes:
       label: Properties File URL
-      description: URL of your properties `.txt` file (e.g. `myLibrary.txt`). It should be in your published release artifacts.
+      description: URL of your properties `.txt` file (e.g. `myLibrary.txt`).
       placeholder: https://
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -9,9 +9,9 @@ body:
 
         Libraries are add-ons that extend the functionality of the Processing language ([read more](https://github.com/processing/processing4/wiki/Library-Overview)).
 
-        Please provide the necessary information below.
-
         If you need help creating a library, see the [Library Guidelines](https://github.com/processing/processing4/wiki/Library-Guidelines) or ask on the [Processing Forum](https://discourse.processing.org/).
+
+        Please provide the necessary information below.
 
   - type: input
     id: properties_url

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -24,6 +24,9 @@ body:
         - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myLibrary.txt`
         - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myLibrary.zip`
 
+        > [!IMPORTANT]
+        > Make sure to keep the same URL in the future. If you release a new version, the URL should remain the same.
+
         For more details, see the [Release Artifacts section of the Library Guidelines](https://github.com/processing/processing4/wiki/Library-Guidelines#release-artifacts).
   - type: input
     id: properties_url

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -42,7 +42,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Once you submit this form, the `library.properties` file at the provided URL will be parsed and validated.
+        Once you submit this form, the `.txt` file at the provided URL will be parsed and validated.
 
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your library to the repository.

--- a/.github/ISSUE_TEMPLATE/1_new-library.yml
+++ b/.github/ISSUE_TEMPLATE/1_new-library.yml
@@ -15,9 +15,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the `.txt` File
+        ### About the Properties File
 
-        The `.txt` file (e.g., `myLibrary.txt`) is necessary for submitting your library. It should be a direct copy of your `library.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+        A properties file (e.g., `myLibrary.txt`) is necessary for submitting your library. It should be a direct copy of your `library.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -12,12 +12,22 @@ body:
         If you need help creating a tool, see the [Tool Guidelines](https://github.com/processing/processing/wiki/Tool-Guidelines) or ask on the [Processing Forum](https://discourse.processing.org/).
 
         Please provide the necessary information below.
+  - type: markdown
+    attributes:
+      value: |
+        ### About the `.txt` File
 
+        The `.txt` file (e.g., `myTool.txt`) is necessary for submitting your tool. It should be a direct copy of your `tool.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+
+        **Example:**
+        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://mywebsite.com/releases/latest/myTool.txt`
+        - `.zip` file: `https://mywebsite.com/releases/latest/myTool.zip`
   - type: input
     id: properties_url
     attributes:
       label: Properties File URL
-      description: URL of your properties `.txt` file (e.g. `myTool.txt`). It should be in your published release artifacts.
+      description: URL of your properties `.txt` file (e.g. `myTool.txt`).
       placeholder: https://
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -15,7 +15,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the Properties File
+        #### About the Properties File
 
         A properties file (e.g., `myTool.txt`) is necessary for submitting your tool. It should be a direct copy of your `tool.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -42,7 +42,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Once you submit this form, the `tool.properties` file at the provided URL will be parsed and validated.
+        Once you submit this form, the `.txt` file at the provided URL will be parsed and validated.
 
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your tool to the repository.

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -23,6 +23,9 @@ body:
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
         - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myTool.txt`
         - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myTool.zip`
+
+        > [!IMPORTANT]
+        > Make sure to keep the same URL in the future. If you release a new version, the URL should remain the same.
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -20,9 +20,9 @@ body:
         The `.txt` file (e.g., `myTool.txt`) is necessary for submitting your tool. It should be a direct copy of your `tool.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
-        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
-        - `.txt` file: `https://mywebsite.com/releases/latest/myTool.txt`
-        - `.zip` file: `https://mywebsite.com/releases/latest/myTool.zip`
+        If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myTool.txt`
+        - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myTool.zip`
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/2_new-tool.yml
+++ b/.github/ISSUE_TEMPLATE/2_new-tool.yml
@@ -15,9 +15,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the `.txt` File
+        ### About the Properties File
 
-        The `.txt` file (e.g., `myTool.txt`) is necessary for submitting your tool. It should be a direct copy of your `tool.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+        A properties file (e.g., `myTool.txt`) is necessary for submitting your tool. It should be a direct copy of your `tool.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -12,12 +12,22 @@ body:
         If you need help creating a mode, see the [Mode Overview](https://github.com/processing/processing/wiki/Mode-Overview) or ask on the [Processing Forum](https://discourse.processing.org/).
 
         Please provide the necessary information below.
+  - type: markdown
+    attributes:
+      value: |
+        ### About the `.txt` File
 
+        The `.txt` file (e.g., `myMode.txt`) is necessary for submitting your mode. It should be a direct copy of your `mode.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+
+        **Example:**
+        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://mywebsite.com/releases/latest/myMode.txt`
+        - `.zip` file: `https://mywebsite.com/releases/latest/myMode.zip`
   - type: input
     id: properties_url
     attributes:
       label: Properties File URL
-      description: URL of your properties `.txt` file (e.g. `myMode.txt`). It should be in your published release artifacts.
+      description: URL of your properties `.txt` file (e.g. `myMode.txt`).
       placeholder: https://
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -23,6 +23,9 @@ body:
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
         - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myMode.txt`
         - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myMode.zip`
+
+        > [!IMPORTANT]
+        > Make sure to keep the same URL in the future. If you release a new version, the URL should remain the same.
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -20,9 +20,9 @@ body:
         The `.txt` file (e.g., `myMode.txt`) is necessary for submitting your mode. It should be a direct copy of your `mode.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
-        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
-        - `.txt` file: `https://mywebsite.com/releases/latest/myMode.txt`
-        - `.zip` file: `https://mywebsite.com/releases/latest/myMode.zip`
+        If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myMode.txt`
+        - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myMode.zip`
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -15,7 +15,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the Properties File
+        #### About the Properties File
 
         A properties file (e.g., `myMode.txt`) is necessary for submitting your mode. It should be a direct copy of your `mode.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -42,7 +42,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Once you submit this form, the `mode.properties` file at the provided URL will be parsed and validated.
+        Once you submit this form, the `.txt` file at the provided URL will be parsed and validated.
 
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your mode to the repository.

--- a/.github/ISSUE_TEMPLATE/3_new-mode.yml
+++ b/.github/ISSUE_TEMPLATE/3_new-mode.yml
@@ -15,9 +15,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the `.txt` File
+        ### About the Properties File
 
-        The `.txt` file (e.g., `myMode.txt`) is necessary for submitting your mode. It should be a direct copy of your `mode.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+        A properties file (e.g., `myMode.txt`) is necessary for submitting your mode. It should be a direct copy of your `mode.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -20,9 +20,9 @@ body:
         The `.txt` file (e.g., `myExamples.txt`) is necessary for submitting your example pack. It should be a direct copy of your `examples.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
-        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
-        - `.txt` file: `https://mywebsite.com/releases/latest/myExamples.txt`
-        - `.zip` file: `https://mywebsite.com/releases/latest/myExamples.zip`
+        If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myExamples.txt`
+        - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myExamples.zip`
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -15,9 +15,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the `.txt` File
+        ### About the Properties File
 
-        The `.txt` file (e.g., `myExamples.txt`) is necessary for submitting your example pack. It should be a direct copy of your `examples.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+        A properties file (e.g., `myExamples.txt`) is necessary for submitting your example pack. It should be a direct copy of your `examples.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 
         **Example:**
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -15,7 +15,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ### About the Properties File
+        #### About the Properties File
 
         A properties file (e.g., `myExamples.txt`) is necessary for submitting your example pack. It should be a direct copy of your `examples.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
 

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -23,6 +23,9 @@ body:
         If your release artifacts are hosted at `https://github.com/yourusername/yourrepo/releases/latest/`, ensure these files are available:
         - `.txt` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myExamples.txt`
         - `.zip` file: `https://github.com/yourusername/yourrepo/releases/latest/download/myExamples.zip`
+
+        > [!IMPORTANT]
+        > Make sure to keep the same URL in the future. If you release a new version, the URL should remain the same.
   - type: input
     id: properties_url
     attributes:

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -42,7 +42,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Once you submit this form, the `examples.properties` file at the provided URL will be parsed and validated.
+        Once you submit this form, the `.txt` file at the provided URL will be parsed and validated.
 
         The result of this validation will be added to this issue:
         - If valid, a pull request will automatically be created to add your example pack to the repository.

--- a/.github/ISSUE_TEMPLATE/4_new-examples.yml
+++ b/.github/ISSUE_TEMPLATE/4_new-examples.yml
@@ -12,12 +12,22 @@ body:
         If you need help creating an example pack, see the [Examples Overview](https://github.com/processing/processing/wiki/Examples-Overview) or ask on the [Processing Forum](https://discourse.processing.org/).
 
         Please provide the necessary information below.
+  - type: markdown
+    attributes:
+      value: |
+        ### About the `.txt` File
 
+        The `.txt` file (e.g., `myExamples.txt`) is necessary for submitting your example pack. It should be a direct copy of your `examples.properties` file, hosted in the same directory as your `.zip` distribution, and share the same base name.
+
+        **Example:**
+        If your release artifacts are hosted at `https://mywebsite.com/releases/latest/`, ensure these files are available:
+        - `.txt` file: `https://mywebsite.com/releases/latest/myExamples.txt`
+        - `.zip` file: `https://mywebsite.com/releases/latest/myExamples.zip`
   - type: input
     id: properties_url
     attributes:
       label: Properties File URL
-      description: URL of your properties `.txt` file (e.g. `myExamples.txt`). It should be in your published release artifacts.
+      description: URL of your properties `.txt` file (e.g. `myExamples.txt`).
       placeholder: https://
     validations:
       required: true


### PR DESCRIPTION
Added clearer instructions about required files (e.g., `.txt` and `.zip`) with examples for proper hosting, and link to the Guidelines to help contributors meet requirements more easily.