### PR TITLE
Proscene is deprecated

### DIFF
--- a/contributions.yaml
+++ b/contributions.yaml
@@ -1,7 +1,7 @@
 contributions:
 - id: 1
   source: https://github.com/remixlab/proscene/releases/download/latest/proscene.txt
-  status: VALID
+  status: DEPRECATED
   type: library
   name: proscene
   authors: '[Jean Pierre Charalambos](http://otrolado.info)'


### PR DESCRIPTION
Proscene is deprecated and has been replaced by [nub](https://github.com/VisualComputing/nub).

Setting the `status` flag to `DEPRECATED` in the `.yaml` file.