### PR TITLE
use javaproperties library to parse

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ ruamel.yaml
 tenacity~=9.0.0
 requests~=2.32.3
 pydantic~=2.9.2
+javaproperties~=0.8.2


### PR DESCRIPTION
This PR addresses #76 by using a library specifically designed to treat java property files in python. 
This means all escaped characters will be dealt with properly.

This was tested with the VJ Motion library, which does have an escaped colon in the value of url.

the output for the script is below, showing no escaped colons in the values.

properties dict: {'type': 'library', 'source': 'https://github.com/vincentsijben/vjmotion-processing/releases/latest/download/VJMotion.txt', 'name': 'VJ Motion', 'authors': '[Vincent Sijben](https://github.com/vincentsijben)', 'url': 'https://vincentsijben.github.io/vjmotion-processing/', 'categories': 'Sound,Utilities,Math', 'sentence': 'A collection of helper functions to create live, audio-reactive visuals with BPM-synced animation, Arduino input and frequency analyzing.', 'paragraph': '', 'version': 8, 'prettyVersion': '0.0.8', 'minRevision': 0, 'maxRevision': 0}
T