### PR TITLE
Readd parsing inline comment

### DIFF
--- a/contributions.yaml
+++ b/contributions.yaml
@@ -5359,8 +5359,8 @@ contributions:
   source: 
     https://github.com/alexdmiller/shape-mapper/releases/latest/download/shapemapper.txt
   name: Shape Mapper
-  authors: '[Alex Miller](https\://alexmiller.cv/)'
-  url: https\://github.com/alexdmiller/shape-mapper
+  authors: '[Alex Miller](https://alexmiller.cv/)'
+  url: https://github.com/alexdmiller/shape-mapper
   categories:
   - 3D
   sentence: Projection mapping library for 3D models
@@ -5401,8 +5401,8 @@ contributions:
   source: 
     https://github.com/vincentsijben/vjmotion-processing/releases/latest/download/VJMotion.txt
   name: VJ Motion
-  authors: '[Vincent Sijben](https\://github.com/vincentsijben)'
-  url: https\://vincentsijben.github.io/vjmotion-processing/
+  authors: '[Vincent Sijben](https://github.com/vincentsijben)'
+  url: https://vincentsijben.github.io/vjmotion-processing/
   categories:
   - Math
   - Sound

--- a/scripts/parse_and_validate_properties_txt.py
+++ b/scripts/parse_and_validate_properties_txt.py
@@ -73,7 +73,11 @@ def read_properties_txt(properties_url):
     return r.text
 
 def parse_text(properties_raw):
-    return jp.loads(properties_raw)
+    properties_dict = {
+        key: value.split('#')[0].strip() if isinstance(value, str) else value
+        for key, value in jp.loads(properties_raw).items()
+    }
+    return properties_dict
 
 def validate_existing(properties_dict):
     # validation on existing contribution is weaker


### PR DESCRIPTION
adds back in the removal of inline hash comments. Note that this is not standard Java properties behavior. Java property files do not allow inline comments. However, many properties.txt files have inline comments for the version fields.

remove the backslash from recent urls - these will not be replaced automatically, since updates to the entry only happen when a version changes, or when a link is broken it is logged.