### PR TITLE
json dump dictionary before outputing to github actions

### DIFF
--- a/scripts/parse_and_validate_properties_txt.py
+++ b/scripts/parse_and_validate_properties_txt.py
@@ -147,4 +147,4 @@ if __name__ == "__main__":
     contribution.update(props)
 
     print(f"properties dict: {contribution}")  # just for debugging, should do this via logging levels
-    set_output(contribution)
+    set_output(json.dumps(contribution))


### PR DESCRIPTION
currently the code outputs to github the dictionary. However, we are having an issue of an unescaped apostrophe. Here we use the json library to dump to a string, in hopes that it will properly escape characters.