### PR TITLE
replace single quotes with escaped

### DIFF
--- a/scripts/parse_and_validate_properties_txt.py
+++ b/scripts/parse_and_validate_properties_txt.py
@@ -131,6 +131,9 @@ if __name__ == "__main__":
 
     print(f"properties text: {properties_raw}")  # just for debugging, should do this via logging levels
 
+    # replace occurrences of single quotes with two single quotes.
+    # this is because github actions will delimit strings with single quotes, and escapes single quotes this way
+    properties_raw = properties_raw.replace("'", "''")
     try:
         if type_ == 'library':
             props = validate_new_library(parse_text(properties_raw))
@@ -147,4 +150,4 @@ if __name__ == "__main__":
     contribution.update(props)
 
     print(f"properties dict: {contribution}")  # just for debugging, should do this via logging levels
-    set_output(json.dumps(contribution))
+    set_output(contribution)


### PR DESCRIPTION
Github actions specifically quotes strings with single quotes, and to escape single quotes within the string, you need two single quotes. To account for this, do simple string replace of single quote to two single quotes when parsing the properties file.

revert json dump of dictionary - later python receives a string, not a dictionary