### PR TITLE
fix revision fields in latest contributions

### DIFF
--- a/contributions.yaml
+++ b/contributions.yaml
@@ -5836,8 +5836,8 @@ contributions:
     Guide to Programming Images, Animation, and Interaction."
   version: '1'
   prettyVersion: '1'
-  minVersion: '0'
-  maxVersion: '0'
+  minRevision: 0
+  maxRevision: 0
   download: 
     https://github.com/shiffman/LearningProcessing/releases/download/2025-update/learningprocessing2.zip
   lastUpdated: 2025-09-04T04:47:24+0000
@@ -5858,8 +5858,8 @@ contributions:
   paragraph: All examples from the Nature of Code book, ported to Processing.
   version: '1'
   prettyVersion: '1'
-  minVersion: '0'
-  maxVersion: '0'
+  minRevision: 0
+  maxRevision: 0
   download: 
     https://github.com//nature-of-code/noc-2-processing-port/releases/latest/download/noc-2-processing-port.zip
   lastUpdated: 2025-09-04T04:47:24+0000


### PR DESCRIPTION
latest contributions didn't have min/max Revision as fields, which broke the update script.
As first fix, manually add revision fields, and remove the min/max Version fields.