### PR TITLE
Add C++ Mode

### DIFF
--- a/contributions.yaml
+++ b/contributions.yaml
@@ -6355,3 +6355,22 @@ contributions:
     https://raw.githubusercontent.com/mstrperson/Processing-Sprite/master/releases/download/latest/SpriteGame.zip
   log:
   - invalid file, 2026-05-09
+- id: 306
+  status: VALID
+  dateAdded: 2026-05-14T00:00:00+0000
+  type: mode
+  source: https://github.com/processing-cpp/processing.cpp/releases/download/v0.1.0/CppMode.zip
+  name: C++ Mode
+  authors: '[Jose Gonzalez Llamas](https://github.com/pepc84)'
+  url: https://github.com/processing-cpp/processing.cpp
+  categories:
+  - Other
+  sentence: Write and run Processing sketches in C++.
+  paragraph: C++ Mode lets you write sketches using the familiar Processing API —
+    size(), ellipse(), mouseX, draw() — but compiled to a native binary via g++.
+    Runs on Linux, macOS, and Windows (via MSYS2). Requires g++ and OpenGL (GLFW + GLEW).
+  version: '1'
+  prettyVersion: 0.1.0
+  minRevision: 1280
+  maxRevision: 0
+  download: https://github.com/processing-cpp/processing.cpp/releases/download/v0.1.0/CppMode.zip


### PR DESCRIPTION
Adding C++ Mode — write and run Processing sketches in C++ compiled to a native binary via g++.