### PR TITLE
Update the URL for "Python Mode for Processing 4"

### DIFF
--- a/contributions.yaml
+++ b/contributions.yaml
@@ -5902,7 +5902,7 @@ contributions:
     https://py.processing.org/4/PythonMode.txt
   name: Python Mode for Processing 4
   authors: '[Jonathan Feinberg](http://MrFeinberg.com/)'
-  url: https://github.com/jdf/processing.py
+  url: https://github.com/jdf/processing.py/tree/processing4
   categories: []
   sentence: Write Processing 4 sketches in Python.
   paragraph: ''


### PR DESCRIPTION
The main branch states that

> It is not compatible with the latest major version of Processing, 4.0.

> There is no longer anyone fixing bugs or developing new features.

which gives the impression that this entry is a stale and should be removed from the list.

Thanks to @SableRaf for sharing the branch that the actual work lives on.